### PR TITLE
Declare the platform explicitly for all Ubundu default dockerfiles

### DIFF
--- a/Dockerfiles/Dockerfile.riscv64.ubuntu20.04
+++ b/Dockerfiles/Dockerfile.riscv64.ubuntu20.04
@@ -1,4 +1,4 @@
-FROM riscv64/ubuntu:20.04
+FROM --platform=linux/riscv64 riscv64/ubuntu:20.04
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.riscv64.ubuntu22.04
+++ b/Dockerfiles/Dockerfile.riscv64.ubuntu22.04
@@ -1,4 +1,4 @@
-FROM riscv64/ubuntu:22.04
+FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh


### PR DESCRIPTION
Origin patch : https://github.com/uraimo/run-on-arch-action/commit/96c27aa6978f736220aea94414920135028189be#diff-8016e1ce422ffb06b471e53ac55f8c38ffed897a40bdfedb71555cd0a623a677R3